### PR TITLE
Enable operations endpoint for peer and orderer (resolves #30)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Example Playbook
             # The name to use for this Docker container and associated Docker volumes.
             name: ca.org1.example.com
             # The external port to use for this Docker container.
-            port: 17054
+            port: 18050
           # IBM Blockchain Platform on IBM Cloud specific configuration.
           ibp:
             # The display name of this CA.
@@ -133,15 +133,17 @@ Example Playbook
               # The name to use for this Docker container and associated Docker volumes.
               name: peer0.org1.example.com
               # The external request port to use for this Docker container.
-              port: 17051
+              port: 18051
               # The external chaincode port to use for this Docker container.
-              chaincode_port: 17052
+              chaincode_port: 18052
+              # The external operations port to use for this Docker container.
+              operations_port: 18053
               # CouchDB specific configuration.
               couchdb:
                 # The name to use for the CouchDB Docker container and associated Docker volumes.
                 name: couchdb0.org1.example.com
                 # The external CouchDB port to use for the CouchDB Docker container.
-                port: 5984
+                port: 18054
             # IBM Blockchain Platform on IBM Cloud specific configuration.
             ibp:
               # The display name of this peer.
@@ -182,7 +184,7 @@ Example Playbook
             # The name to use for this Docker container and associated Docker volumes.
             name: ca.orderer.example.com
             # The external port to use for this Docker container.
-            port: 19054
+            port: 17050
           # IBM Blockchain Platform on IBM Cloud specific configuration.
           ibp:
             # The display name of this CA.
@@ -216,7 +218,9 @@ Example Playbook
             # The name to use for this Docker container and associated Docker volumes.
             name: orderer.example.com
             # The external port to use for this Docker container.
-            port: 17050
+            port: 17051
+            # The external operations port to use for this Docker container.
+            operations_port: 17052
           # IBM Blockchain Platform on IBM Cloud specific configuration.
           ibp:
             # The display name of this orderer.

--- a/tasks/docker/create-orderer.yml
+++ b/tasks/docker/create-orderer.yml
@@ -104,8 +104,15 @@
       ORDERER_GENERAL_LOCALMSPID: "{{ organization.msp.id }}"
       ORDERER_GENERAL_SYSTEMCHANNEL: testchainid
       ORDERER_GENERAL_TLS_ENABLED: "{{ 'true' if orderer.tls.enabled else 'false' }}"
+      ORDERER_OPERATIONS_LISTENADDRESS: 0.0.0.0:{{ orderer.docker.operations_port }}
+      ORDERER_OPERATIONS_TLS_ENABLED: "{{ 'true' if orderer.tls.enabled else 'false' }}"
+      ORDERER_OPERATIONS_TLS_CERTIFICATE: /etc/hyperledger/fabric/tls/server.crt
+      ORDERER_OPERATIONS_TLS_PRIVATEKEY: /etc/hyperledger/fabric/tls/server.key
+      ORDERER_OPERATIONS_TLS_CLIENTROOTCAS: /etc/hyperledger/fabric/tls/ca.crt
+      ORDERER_METRICS_PROVIDER: prometheus
     published_ports:
       - "{{ orderer.docker.port }}:{{ orderer.docker.port }}"
+      - "{{ orderer.docker.operations_port }}:{{ orderer.docker.operations_port }}"
     volumes:
       - "{{ orderer.docker.name }}-msp:/etc/hyperledger/fabric/msp"
       - "{{ orderer.docker.name }}-tls:/etc/hyperledger/fabric/tls"
@@ -178,6 +185,16 @@
     state: started
     restart: yes
   when: check_orderer_msp.rc != 0 or check_orderer_tls.rc != 0 or check_orderer_genesis_block.rc != 0
+
+- name: Wait for orderer to start
+  uri:
+    url: "{{ 'https' if orderer.tls.enabled else 'http' }}://localhost:{{ orderer.docker.operations_port }}/healthz"
+    status_code: "200"
+    validate_certs: no
+  register: result
+  until: result.status == 200
+  retries: 60
+  delay: 1
 
 - name: Update orderer facts
   set_fact:

--- a/tasks/docker/create-peer.yml
+++ b/tasks/docker/create-peer.yml
@@ -136,9 +136,16 @@
       CORE_CHAINCODE_NODE_RUNTIME: hyperledger/fabric-baseimage:0.4.15
       CORE_LEDGER_STATE_STATEDATABASE: "{{ 'CouchDB' if peer.database_type is defined and peer.database_type == 'couchdb' else 'goleveldb' }}"
       CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS: "{{ peer.docker.couchdb.name + ':5984' if peer.database_type is defined and peer.database_type == 'couchdb' else '' }}"
+      CORE_OPERATIONS_LISTENADDRESS: 0.0.0.0:{{ peer.docker.operations_port }}
+      CORE_OPERATIONS_TLS_ENABLED: "{{ 'true' if peer.tls.enabled else 'false' }}"
+      CORE_OPERATIONS_TLS_CERT_FILE: /etc/hyperledger/fabric/tls/server.crt
+      CORE_OPERATIONS_TLS_KEY_FILE: /etc/hyperledger/fabric/tls/server.key
+      CORE_OPERATIONS_TLS_CLIENTROOTCAS_FILES: /etc/hyperledger/fabric/tls/ca.crt
+      CORE_METRICS_PROVIDER: prometheus
     published_ports:
       - "{{ peer.docker.port }}:{{ peer.docker.port }}"
       - "{{ peer.docker.chaincode_port }}:{{ peer.docker.chaincode_port }}"
+      - "{{ peer.docker.operations_port }}:{{ peer.docker.operations_port }}"
     volumes:
       - "{{ peer.docker.name }}-msp:/etc/hyperledger/fabric/msp"
       - "{{ peer.docker.name }}-tls:/etc/hyperledger/fabric/tls"
@@ -183,6 +190,16 @@
     state: started
     restart: yes
   when: check_peer_msp.rc != 0 or check_peer_tls.rc != 0
+
+- name: Wait for peer to start
+  uri:
+    url: "{{ 'https' if peer.tls.enabled else 'http' }}://localhost:{{ peer.docker.operations_port }}/healthz"
+    status_code: "200"
+    validate_certs: no
+  register: result
+  until: result.status == 200
+  retries: 60
+  delay: 1
 
 - name: Update peer facts
   set_fact:


### PR DESCRIPTION
- Enable operations endpoint for peer and orderer when started using Docker.
- Add additional configuration for operations port for peer and orderer when using Docker.
- Wait for peer and orderer to start by pinging operations endpoint.
- Update documentation.

Signed-off-by: Simon Stone <sstone1@uk.ibm.com>