### PR TITLE
Missing comma in Peer/Orderer Nodes JSON

### DIFF
--- a/templates/saas/orderer-node.json.j2
+++ b/templates/saas/orderer-node.json.j2
@@ -2,7 +2,7 @@
 {
     "short_name": "{{ orderer.id }}",
     "name": "{{ orderer.ibp.display_name }}",
-    "api_url": "{{ ibp[orderer.id].protocol }}://{{ ibp[orderer.id].hostname }}:{{ ibp[orderer.id].port }}"
+    "api_url": "{{ ibp[orderer.id].protocol }}://{{ ibp[orderer.id].hostname }}:{{ ibp[orderer.id].port }}",
     {% if ibp[orderer.id].protocol == 'grpcs' %}
     "pem": "{{ lookup('file', ibp[orderer.id].pem) | b64encode }}",
     {% endif %}

--- a/templates/saas/peer-node.json.j2
+++ b/templates/saas/peer-node.json.j2
@@ -2,7 +2,7 @@
 {
     "short_name": "{{ peer.id }}",
     "name": "{{ peer.ibp.display_name }}",
-    "api_url": "{{ ibp[peer.id].protocol }}://{{ ibp[peer.id].hostname }}:{{ ibp[peer.id].port }}"
+    "api_url": "{{ ibp[peer.id].protocol }}://{{ ibp[peer.id].hostname }}:{{ ibp[peer.id].port }}",
     {% if ibp[peer.id].protocol == 'grpcs' %}
     "pem": "{{ lookup('file', ibp[peer.id].pem) | b64encode }}",
     {% endif %}

--- a/templates/software/orderer-node.json.j2
+++ b/templates/software/orderer-node.json.j2
@@ -2,7 +2,7 @@
 {
     "short_name": "{{ orderer.id }}",
     "name": "{{ orderer.ibp.display_name }}",
-    "api_url": "{{ ibp[orderer.id].protocol }}://{{ ibp[orderer.id].hostname }}:{{ ibp[orderer.id].port }}"
+    "api_url": "{{ ibp[orderer.id].protocol }}://{{ ibp[orderer.id].hostname }}:{{ ibp[orderer.id].port }}",
     {% if ibp[orderer.id].protocol == 'grpcs' %}
     "pem": "{{ lookup('file', ibp[orderer.id].pem) | b64encode }}",
     {% endif %}

--- a/templates/software/peer-node.json.j2
+++ b/templates/software/peer-node.json.j2
@@ -2,7 +2,7 @@
 {
     "short_name": "{{ peer.id }}",
     "name": "{{ peer.ibp.display_name }}",
-    "api_url": "{{ ibp[peer.id].protocol }}://{{ ibp[peer.id].hostname }}:{{ ibp[peer.id].port }}"
+    "api_url": "{{ ibp[peer.id].protocol }}://{{ ibp[peer.id].hostname }}:{{ ibp[peer.id].port }}",
     {% if ibp[peer.id].protocol == 'grpcs' %}
     "pem": "{{ lookup('file', ibp[peer.id].pem) | b64encode }}",
     {% endif %}


### PR DESCRIPTION
Currently Ansible sees the Node files as non-json and adds a bunch of \n.
Adding the missing comma at the end of the API_URL fixes this.

Signed-off-by: Luc Desrosiers <ldesrosi@uk.ibm.com>