### PR TITLE
Set CORE_CHAINCODE_MODE=dev for non TLS networks (resolves #137)

### DIFF
--- a/tasks/docker/create-peer.yml
+++ b/tasks/docker/create-peer.yml
@@ -147,6 +147,7 @@
       CORE_CHAINCODE_GOLANG_RUNTIME: hyperledger/fabric-baseos:0.4.18
       CORE_CHAINCODE_JAVA_RUNTIME: hyperledger/fabric-javaenv:1.4.4
       CORE_CHAINCODE_NODE_RUNTIME: hyperledger/fabric-baseimage:0.4.18
+      CORE_CHAINCODE_MODE: "{{ 'net' if peer.tls.enabled else 'dev' }}"
       CORE_LEDGER_STATE_STATEDATABASE: "{{ 'CouchDB' if peer.database_type is defined and peer.database_type == 'couchdb' else 'goleveldb' }}"
       CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS: "{{
         peer.docker.couchdb.hostname + ':5984' if peer.database_type is defined and peer.database_type == 'couchdb' else ''


### PR DESCRIPTION
Signed-off-by: Simon Stone <sstone1@uk.ibm.com>