### PR TITLE
Added init param to contract deployment

### DIFF
--- a/tasks/docker/create-peer.yml
+++ b/tasks/docker/create-peer.yml
@@ -148,6 +148,7 @@
       CORE_CHAINCODE_JAVA_RUNTIME: hyperledger/fabric-javaenv:2.0.0
       CORE_CHAINCODE_NODE_RUNTIME: hyperledger/fabric-nodeenv:2.0.0
       CORE_CHAINCODE_MODE: "{{ 'net' if peer.tls.enabled else 'dev' }}"
+      CORE_CHAINCODE_EXECUTETIMEOUT: "300s"
       CORE_LEDGER_STATE_STATEDATABASE: "{{ 'CouchDB' if peer.database_type is defined and peer.database_type == 'couchdb' else 'goleveldb' }}"
       CORE_LEDGER_STATE_COUCHDBCONFIG_COUCHDBADDRESS: "{{
         peer.docker.couchdb.hostname + ':5984' if peer.database_type is defined and peer.database_type == 'couchdb' else ''

--- a/tasks/manage-contract/commit-contract.yml
+++ b/tasks/manage-contract/commit-contract.yml
@@ -16,6 +16,7 @@
     -C {{ channel.name }}
     -n {{ definition.name }}
     -v {{ definition.version }}
+    {{ '--init-required' if definition.init is defined else '' }}
     --sequence {{ sequence_number }}
     -o {{ ibp[channel.orderer.id].hostname }}:{{ ibp[channel.orderer.id].port }}
     {{ '--tls' if ibp[channel.orderer.id].protocol == 'grpcs' else '' }}

--- a/tasks/manage-contract/definition.yml
+++ b/tasks/manage-contract/definition.yml
@@ -14,3 +14,7 @@
 - name: Commit contract in the channel
   include_tasks: commit-contract.yml
   when: new_sequence_number_reqd
+
+- name: Init contract on the channel
+  include_tasks: init-contract.yml
+  when: new_sequence_number_reqd

--- a/tasks/manage-contract/init-contract.yml
+++ b/tasks/manage-contract/init-contract.yml
@@ -2,19 +2,20 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 ---
-- name: Select peer to use for approve operations
+- name: Select member to use for init operation
+  set_fact:
+    member: "{{ definition.endorsing_members[0] }}"
+
+- name: Select peer to use for commit operation
   set_fact:
     peer: "{{ member.endorsing_peers[0] }}"
 
-- name: Approve contract
+- name: Initialize contract
   command: >
-    peer lifecycle chaincode approveformyorg
+    peer chaincode invoke --isInit --waitForEvent
     -C {{ channel.name }}
     -n {{ definition.name }}
-    -v {{ definition.version }}
-    {{ '--init-required' if definition.init is defined else '' }}
-    --package-id {{ package_id }}
-    --sequence {{ sequence_number }}
+    -c '{{ definition.init }}'
     -o {{ ibp[channel.orderer.id].hostname }}:{{ ibp[channel.orderer.id].port }}
     {{ '--tls' if ibp[channel.orderer.id].protocol == 'grpcs' else '' }}
     {{ '--cafile "' + ibp[channel.orderer.id].pem + '"' if ibp[channel.orderer.id].protocol == 'grpcs' else '' }}
@@ -25,4 +26,5 @@
       CORE_PEER_LOCALMSPID: "{{ member.msp.id }}"
       CORE_PEER_TLS_ENABLED: "{{ 'true' if peer.tls.enabled else 'false' }}"
       CORE_PEER_TLS_ROOTCERT_FILE: "{{ ibp[peer.id].pem if ibp[peer.id].pem is defined }}"
+  when: definition.init is defined
   changed_when: True


### PR DESCRIPTION
On the issue-94 / Fabric 2.0 support branch, I added the ability to initialize the contract using the init parameter as in this example:
```
    contracts:
      - package: "{{ source.contracts.trade }}"
        channels:
          - <<: *TradeChannel
            definitions:
              - name: trade
                version: 1.0.0
                init: '{"Args":["init","ExporterOrgMSP", "ExporterBank", "1000","ImporterOrgMSP","ImporterBank","1000"]}'
                endorsement_policy: "AND(ExporterOrg.member','ImporterOrg.member')"
                endorsing_members:
                  - <<: *ExporterOrg
                    endorsing_peers:
                      - <<: *ExporterOrgPeer1
```
Signed-off-by: Luc Desrosiers <ldesrosi@uk.ibm.com>